### PR TITLE
Various general improvements

### DIFF
--- a/TabSanity/BackspaceDeleteKeyFilter.cs
+++ b/TabSanity/BackspaceDeleteKeyFilter.cs
@@ -1,90 +1,144 @@
-﻿using EnvDTE;
-using EnvDTE80;
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using System;
+using IServiceProvider = System.IServiceProvider;
 
 namespace TabSanity
 {
-	internal class BackspaceDeleteKeyFilter : TabOptionsListener
+	internal class BackspaceDeleteKeyFilter : KeyFilter
 	{
-		private readonly TextDocumentKeyPressEvents _keyPressEvents;
-		private const string BACKSPACE_KEY = "\b";
-		private const string DELETE_KEY = "";
-
-		public BackspaceDeleteKeyFilter(_DTE app, IWpfTextView textView)
-			: base(textView)
+		public BackspaceDeleteKeyFilter(DisplayWindowHelper displayHelper, IWpfTextView textView, IServiceProvider provider)
+			: base(displayHelper, textView, provider)
 		{
-			var events = (Events2)app.Events;
-			// ReSharper disable RedundantArgumentDefaultValue
-			_keyPressEvents = events.TextDocumentKeyPressEvents[null];
-			// ReSharper restore RedundantArgumentDefaultValue
-			_keyPressEvents.BeforeKeyPress += BeforeKeyPress;
 		}
 
-		protected override void OnConvertTabsToSpacesOptionChanged()
+		public override int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
 		{
-			base.OnConvertTabsToSpacesOptionChanged();
-			_keyPressEvents.BeforeKeyPress -= BeforeKeyPress;
-			if (ConvertTabsToSpaces)
-				_keyPressEvents.BeforeKeyPress += BeforeKeyPress;
-		}
-
-		private void BeforeKeyPress(string keypress, TextSelection selection,
-									bool inStatementCompletion, ref bool cancelKeypress)
-		{
-			if (!ConvertTabsToSpaces || !selection.IsEmpty || inStatementCompletion) return;
-
-			switch (keypress)
+			if (ConvertTabsToSpaces
+				&& TextView.Selection.IsEmpty
+				&& !CaretIsWithinCodeRange
+				&& !IsInAutomationFunction
+				&& !DisplayHelper.IsCompletionActive
+				&& !DisplayHelper.IsSignatureHelpActive
+				)
 			{
-				case BACKSPACE_KEY:
-					ReplaceVirtualSpaces(selection);
+				var handled = false;
 
-					do
+				if (pguidCmdGroup == VSConstants.VSStd2K)
+				{
+					switch ((VSConstants.VSStd2KCmdID)nCmdID)
 					{
-						selection.CharLeft(true);
-						if (selection.Text == " ")
-						{
-							cancelKeypress = true;
-							selection.Delete();
-							continue;
-						}
-						selection.CharRight(true);
-						return;
-					} while (selection.CurrentColumn % IndentSize != 1);
-					return;
+						case VSConstants.VSStd2KCmdID.BACKSPACE:
+							handled = HandleBackspaceKey();
+							break;
 
-				case DELETE_KEY:
-					ReplaceVirtualSpaces(selection);
-
-					for (var i = 0; i < IndentSize; i++)
-					{
-						selection.CharRight(true);
-						if (selection.Text == " ")
-						{
-							cancelKeypress = true;
-							selection.Delete();
-							continue;
-						}
-						selection.CharLeft(true);
-						return;
+						case VSConstants.VSStd2KCmdID.DELETE:
+							handled = HandleDeleteKey();
+							break;
 					}
-					return;
+				}
+				else if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
+				{
+					switch ((VSConstants.VSStd97CmdID)nCmdID)
+					{
+						case VSConstants.VSStd97CmdID.Delete:
+							handled = HandleDeleteKey();
+							break;
+					}
+				}
+
+				if (handled)
+				{
+					return VSConstants.S_OK;
+				}
 			}
+
+			return NextTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
 		}
 
-		private void ReplaceVirtualSpaces(TextSelection selection)
+		public override int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)
 		{
-			if (TextView.Caret.InVirtualSpace)
+			return NextTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+		}
+
+		private bool HandleBackspaceKey()
+		{
+			ReplaceVirtualSpaces();
+
+			var snapshot = TextView.TextBuffer.CurrentSnapshot;
+			var caretPos = Caret.Position.BufferPosition.Position;
+
+			// Determine the number of spaces until the previous tab stop.
+			var spacesToRemove = ((CaretColumn - 1) % IndentSize) + 1;
+
+			// Make sure we only delete spaces.
+			for (var i = 0; i < spacesToRemove; i++)
 			{
-				var spaces = TextView.Caret.Position.VirtualSpaces;
-				selection.DeleteWhitespace();
-				selection.PadToColumn(spaces + 1);
+				var snapshotPos = caretPos - 1 - i;
+				if (snapshotPos < 0 || snapshot[snapshotPos] != ' ')
+				{
+					spacesToRemove = i;
+					break;
+				}
+			}
+
+			if (spacesToRemove > 1)
+			{
+				TextView.TextBuffer.Delete(new Span(caretPos - spacesToRemove, spacesToRemove));
+				return true;
+			}
+			else
+			{
+				return false;
 			}
 		}
 
-		public override void Dispose()
+		private bool HandleDeleteKey()
 		{
-			_keyPressEvents.BeforeKeyPress -= BeforeKeyPress;
-			base.Dispose();
+			// If we are in virtual space, we should already be at the end of the line,
+			// so let Visual Studio handle the keypress.
+			if (Caret.InVirtualSpace)
+			{
+				return false;
+			}
+
+			var snapshot = TextView.TextBuffer.CurrentSnapshot;
+			var caretPos = Caret.Position.BufferPosition.Position;
+
+			// Determine the number of spaces until the next tab stop.
+			var spacesToRemove = IndentSize - (CaretColumn % IndentSize);
+
+			// Make sure we only delete spaces.
+			for (var i = 0; i < spacesToRemove; i++)
+			{
+				var snapshotPos = caretPos + i;
+				if (snapshotPos >= snapshot.Length || snapshot[snapshotPos] != ' ')
+				{
+					spacesToRemove = i;
+					break;
+				}
+			}
+
+			if (spacesToRemove > 1)
+			{
+				TextView.TextBuffer.Delete(new Span(caretPos, spacesToRemove));
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		private void ReplaceVirtualSpaces()
+		{
+			if (Caret.InVirtualSpace)
+			{
+				TextView.TextBuffer.Insert(Caret.Position.BufferPosition, new string(' ', Caret.Position.VirtualSpaces));
+				Caret.MoveTo(CaretLine.End);
+			}
 		}
 	}
 }

--- a/TabSanity/KeyFilter.cs
+++ b/TabSanity/KeyFilter.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Formatting;
+using System;
+using IServiceProvider = System.IServiceProvider;
+
+namespace TabSanity
+{
+	internal abstract class KeyFilter : TabOptionsListener, IOleCommandTarget
+	{
+		internal bool Added = false;
+		internal IOleCommandTarget NextTarget = null;
+		protected DisplayWindowHelper DisplayHelper = null;
+
+		private IServiceProvider _serviceProvider = null;
+
+		#region Computed Properties
+
+		protected ITextCaret Caret
+		{
+			get { return TextView.Caret; }
+		}
+
+		protected bool CaretCharIsASpace
+		{
+			get
+			{
+				return Caret.Position.BufferPosition.Position < Caret.Position.BufferPosition.Snapshot.Length
+					&& Caret.Position.BufferPosition.GetChar() == ' ';
+			}
+		}
+
+		protected int CaretColumn
+		{
+			get { return Caret.Position.BufferPosition.Position - CaretLine.Start.Position; }
+		}
+
+		protected bool CaretIsWithinCodeRange
+		{
+			get { return CaretColumn > ColumnAfterLeadingSpaces; }
+		}
+
+		protected ITextViewLine CaretLine
+		{
+			get { return Caret.ContainingTextViewLine; }
+		}
+
+		protected bool CaretPrevCharIsASpace
+		{
+			get
+			{
+				return Caret.Position.BufferPosition.Position > 0
+					&& Caret.Position.BufferPosition.Subtract(1).GetChar() == ' ';
+			}
+		}
+
+		protected int ColumnAfterLeadingSpaces
+		{
+			get
+			{
+				var snapshot = CaretLine.Snapshot;
+				var column = 0;
+				for (var i = CaretLine.Start.Position; i < CaretLine.End.Position; i++)
+				{
+					column++;
+					if (snapshot[i] != ' ') break;
+				}
+				return column;
+			}
+		}
+
+		protected int ColumnBeforeTrailingSpaces
+		{
+			get
+			{
+				var snapshot = CaretLine.Snapshot;
+				var column = CaretLine.Length;
+				for (var i = CaretLine.End.Position - 1; i > CaretLine.Start.Position; i--)
+				{
+					column--;
+					if (snapshot[i] != ' ') break;
+				}
+				return column;
+			}
+		}
+
+		protected bool IsInAutomationFunction
+		{
+			get { return VsShellUtilities.IsInAutomationFunction(_serviceProvider); }
+		}
+
+		protected int VirtualCaretColumn
+		{
+			get
+			{
+				return Caret.Position.BufferPosition.Position +
+					   Caret.Position.VirtualBufferPosition.VirtualSpaces - CaretLine.Start.Position;
+			}
+		}
+
+		#endregion Computed Properties
+
+		public KeyFilter(DisplayWindowHelper displayHelper, IWpfTextView textView, IServiceProvider provider)
+			: base(textView)
+		{
+			DisplayHelper = displayHelper;
+			_serviceProvider = provider;
+		}
+
+		public abstract int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut);
+
+		public abstract int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText);
+	}
+}

--- a/TabSanity/KeyFilterFactory.cs
+++ b/TabSanity/KeyFilterFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.Composition;
-using EnvDTE;
-using Microsoft.VisualStudio;
+﻿using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -8,18 +6,19 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
+using System.ComponentModel.Composition;
 
 namespace TabSanity
 {
-	[Export(typeof (IVsTextViewCreationListener))]
+	[Export(typeof(IVsTextViewCreationListener))]
 	[ContentType("text")]
 	[TextViewRole(PredefinedTextViewRoles.Editable)]
 	internal class KeyFilterFactory : IVsTextViewCreationListener
 	{
-		[Import(typeof (IVsEditorAdaptersFactoryService))] 
+		[Import(typeof(IVsEditorAdaptersFactoryService))]
 		private IVsEditorAdaptersFactoryService _editorFactory;
 
-		[Import] 
+		[Import]
 		private SVsServiceProvider _serviceProvider;
 
 		private DisplayWindowHelper _helperFactory;
@@ -36,19 +35,17 @@ namespace TabSanity
 
 		public void VsTextViewCreated(IVsTextView viewAdapter)
 		{
-			var app = (DTE) _serviceProvider.GetService(typeof (DTE));
 			var view = _editorFactory.GetWpfTextView(viewAdapter);
-			if (app == null || view == null)
+			if (view == null)
 				return;
 
-			// ReSharper disable ObjectCreationAsStatement
-			new BackspaceDeleteKeyFilter(app, view);
-			// ReSharper restore ObjectCreationAsStatement
+			var displayHelper = _helperFactory.ForTextView(view);
 
-			AddCommandFilter(viewAdapter, new ArrowKeyFilter(_helperFactory.ForTextView(view), view));
+			AddCommandFilter(viewAdapter, new ArrowKeyFilter(displayHelper, view, _serviceProvider));
+			AddCommandFilter(viewAdapter, new BackspaceDeleteKeyFilter(displayHelper, view, _serviceProvider));
 		}
 
-		private static void AddCommandFilter(IVsTextView viewAdapter, ArrowKeyFilter commandFilter)
+		private static void AddCommandFilter(IVsTextView viewAdapter, KeyFilter commandFilter)
 		{
 			if (commandFilter.Added) return;
 			//get the view adapter from the editor factory
@@ -57,7 +54,7 @@ namespace TabSanity
 
 			if (hr != VSConstants.S_OK) return;
 			commandFilter.Added = true;
-			//you'll need the next target for Exec and QueryStatus 
+			//you'll need the next target for Exec and QueryStatus
 			if (next != null)
 				commandFilter.NextTarget = next;
 		}

--- a/TabSanity/TabSanity.csproj
+++ b/TabSanity/TabSanity.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ArrowKeyFilter.cs" />
     <Compile Include="BackspaceDeleteKeyFilter.cs" />
     <Compile Include="DisplayWindowHelper.cs" />
+    <Compile Include="KeyFilter.cs" />
     <Compile Include="KeyFilterFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TabOptionsListener.cs" />


### PR DESCRIPTION
Made the following improvements:
- Replaced backspace/delete code using DTE with code that directly
  modifies the text buffer. Backspacing/deleting tabs now occurs in a
  single step, so it takes a single Ctrl+Z to undo. (Replacing virtual
  spaces with real ones causes some backspace operations to take two
  undos. This could probably be improved.)
- Backspace/delete no longer treat whitespace in the middle of code as
  tabs.
- Backspace/delete and arrow keys no longer treat trailing whitespace as
  tabs.
- Fixed a potential ArgumentOutOfRangeException when pressing arrow keys at the end of a file.

I think this makes everything behave as intended (leading spaces are tabs, everything else are spaces), but it's worth checking everything over to make sure I haven't broken anything.
