### PR TITLE
Go to the next line when cursor is in a wrapped line

### DIFF
--- a/TabSanity/ArrowKeyFilter.cs
+++ b/TabSanity/ArrowKeyFilter.cs
@@ -104,8 +104,6 @@ namespace TabSanity
 					case ARROW_DOWN:
 						try
 						{
-//							_snapshotLine = TextView.TextSnapshot.GetLineFromPosition(
-//								Caret.Position.BufferPosition.Add(CaretLine.Length - CaretColumn + 2));
 							_snapshotLine = FindNextLine();
 							MoveCaretToNearestVirtualTabStop();
 						}
@@ -122,10 +120,12 @@ namespace TabSanity
 
 		ITextSnapshotLine FindNextLine()
 		{
-			var current = TextView.TextSnapshot.GetLineFromPosition(Caret.Position.BufferPosition.Position);
-			var next = TextView.TextSnapshot.GetLineFromPosition(Caret.Position.BufferPosition.Add(CaretLine.Length - CaretColumn + 2));
-			if (next.LineNumber == current.LineNumber && next.LineNumber + 1 < TextView.TextSnapshot.LineCount)
-				next = TextView.TextSnapshot.GetLineFromLineNumber(next.LineNumber + 1);
+			var snapshot = TextView.TextSnapshot;
+			var caretBufferPosition = Caret.Position.BufferPosition;
+			var current = snapshot.GetLineFromPosition(caretBufferPosition.Position);
+			var next = snapshot.GetLineFromPosition(caretBufferPosition.Add(CaretLine.Length - CaretColumn + 2));
+			if (next.LineNumber == current.LineNumber && next.LineNumber + 1 < snapshot.LineCount)
+				next = snapshot.GetLineFromLineNumber(next.LineNumber + 1);
 			return next;
 		}
 

--- a/TabSanity/ArrowKeyFilter.cs
+++ b/TabSanity/ArrowKeyFilter.cs
@@ -104,8 +104,9 @@ namespace TabSanity
 					case ARROW_DOWN:
 						try
 						{
-							_snapshotLine = TextView.TextSnapshot.GetLineFromPosition(
-								Caret.Position.BufferPosition.Add(CaretLine.Length - CaretColumn + 2));
+//							_snapshotLine = TextView.TextSnapshot.GetLineFromPosition(
+//								Caret.Position.BufferPosition.Add(CaretLine.Length - CaretColumn + 2));
+							_snapshotLine = FindNextLine();
 							MoveCaretToNearestVirtualTabStop();
 						}
 						catch (ArgumentOutOfRangeException)
@@ -117,6 +118,15 @@ namespace TabSanity
 			}
 
 			return NextTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+		}
+
+		ITextSnapshotLine FindNextLine()
+		{
+			var current = TextView.TextSnapshot.GetLineFromPosition(Caret.Position.BufferPosition.Position);
+			var next = TextView.TextSnapshot.GetLineFromPosition(Caret.Position.BufferPosition.Add(CaretLine.Length - CaretColumn + 2));
+			if (next.LineNumber == current.LineNumber && next.LineNumber + 1 < TextView.TextSnapshot.LineCount)
+				next = TextView.TextSnapshot.GetLineFromLineNumber(next.LineNumber + 1);
+			return next;
 		}
 
 		private void MoveCaretToNearestVirtualTabStop()


### PR DESCRIPTION
This is a simple fix for cursor getting stuck in a wrapped line. It'll move to the next logical line when key down is pressed.

fixes #8 