### PR TITLE
VS2017 warning

### DIFF
--- a/TabSanity/source.extension.vsixmanifest
+++ b/TabSanity/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TabSanity..1ed91e2d-6cc9-41aa-91aa-5c52e88e36bc" Version="1.0.0" Language="en-US" Publisher="Jed Mao" />
+    <Identity Id="TabSanity..1ed91e2d-6cc9-41aa-91aa-5c52e88e36bc" Version="1.0.1" Language="en-US" Publisher="Jed Mao" />
     <DisplayName>TabSanity</DisplayName>
     <Description xml:space="preserve">Navigate through tabs-as-spaces as if they were actually tabs.</Description>
     <MoreInfo>https://github.com/jedhunsaker/tabsanity-vs#tabsanity-visual-studio-package</MoreInfo>

--- a/TabSanity/source.extension.vsixmanifest
+++ b/TabSanity/source.extension.vsixmanifest
@@ -24,4 +24,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ For Visual Studio 2013, please download and install [TabSanity.vsix](https://git
 ## Building
 
 1. Install the [Visual Studio SDK](http://msdn.microsoft.com/en-us/library/vstudio/bb166441(v=vs.110).aspx).
-2. Open the solution file `TabSanity.sln` in [Visual Studio](http://www.microsoft.com/visualstudio/) 2015 or 2017.
+2. Open the solution file `TabSanity.sln` in [Visual Studio](http://www.microsoft.com/visualstudio/) 2017.
 3. Look in `TabSanity/Bin/(Debug|Release)/TabSanity.vsix` and double-click to install.
 
 ## Dependencies

--- a/readme.md
+++ b/readme.md
@@ -6,17 +6,17 @@ navigation will not allow the caret to land within the spaces that form a tab.
 
 ## Installing
 
-This package works with Visual Studio 2015. The easiest way to install
+This package works with Visual Studio 2015 and 2017. The easiest way to install
 the package is with Visual Studio's built-in extension manager. Go to
 `Tools | Extensions and Updates... | Online | Visual Studio Gallery` and search
-for TabSanity. You can also find it on the [Visual Studio Gallery website](http://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328).
+for TabSanity. You can also find it on the [Visual Studio Marketplace website](https://marketplace.visualstudio.com/items?itemName=jedmao.TabSanity-10817).
 
 For Visual Studio 2013, please download and install [TabSanity.vsix](https://github.com/jedmao/tabsanity-vs/raw/master/TabSanity.vs2013/TabSanity.vsix). Thanks @FlipB!
 
 ## Building
 
 1. Install the [Visual Studio SDK](http://msdn.microsoft.com/en-us/library/vstudio/bb166441(v=vs.110).aspx).
-2. Open the solution file `TabSanity.sln` in [Visual Studio](http://www.microsoft.com/visualstudio/) 2015.
+2. Open the solution file `TabSanity.sln` in [Visual Studio](http://www.microsoft.com/visualstudio/) 2015 or 2017.
 3. Look in `TabSanity/Bin/(Debug|Release)/TabSanity.vsix` and double-click to install.
 
 ## Dependencies


### PR DESCRIPTION
The current version from the VS Marketplace seems to work, but warns about its compatiblity with Visual Studio 2017. This PR fixes that. And the project file does not seem to be compatible with VS2015 anymore (probably due to some commits before), so I updated the readme. 

![capture](https://cloud.githubusercontent.com/assets/1003751/23707172/a74c84e8-0411-11e7-841c-779736db03fa.PNG)

The current VSIX Package is here: https://github.com/pragmatrix/tabsanity-vs/releases